### PR TITLE
port over existing changes minus DPML-406

### DIFF
--- a/backend/src/common/util/consts.go
+++ b/backend/src/common/util/consts.go
@@ -25,7 +25,7 @@ const (
 	LabelKeyScheduledWorkflowStatus = constants.FullName + "/status"
 
 	// The maximum byte sizes of the parameter column in package/pipeline DB.
-	MaxParameterBytes = 10000
+	MaxParameterBytes = 20000 // DPML-576
 
 	// LabelKeyWorkflowEpoch is a label on a Workflow.
 	// It captures the epoch at which the workflow was scheduled.

--- a/frontend/src/lib/Buttons.ts
+++ b/frontend/src/lib/Buttons.ts
@@ -74,7 +74,7 @@ export default class Buttons {
         resourceName === 'run'
           ? this._archiveRun(getSelectedIds(), useCurrentResource, callback)
           : this._archiveExperiments(getSelectedIds(), useCurrentResource, callback),
-      disabled: !useCurrentResource,
+      disabled: resourceName === 'run' ? !useCurrentResource : true,
       disabledTitle: useCurrentResource ? undefined : 'Select at least one resource to archive',
       id: 'archiveBtn',
       title: 'Archive',

--- a/frontend/src/pages/NewRun.tsx
+++ b/frontend/src/pages/NewRun.tsx
@@ -527,7 +527,7 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
           <Input
             value={serviceAccount}
             onChange={this.handleChange('serviceAccount')}
-            required={false}
+            required={true}
             label='Service Account'
             variant='outlined'
           />
@@ -1251,6 +1251,7 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
       maxConcurrentRuns,
       runName,
       trigger,
+      serviceAccount,
     } = this.state;
     try {
       if (!pipeline && !workflowFromRun) {
@@ -1261,6 +1262,9 @@ export class NewRun extends Page<NewRunProps, NewRunState> {
       }
       if (!runName) {
         throw new Error('Run name is required');
+      }
+      if (!serviceAccount) {
+        throw new Error('Service account is required');
       }
 
       const hasTrigger = trigger && (!!trigger.cron_schedule || !!trigger.periodic_schedule);

--- a/frontend/src/pages/NewRunV2.tsx
+++ b/frontend/src/pages/NewRunV2.tsx
@@ -303,6 +303,10 @@ function NewRunV2(props: NewRunV2Props) {
   // Whenever any input value changes, validate and show error if needed.
   useEffect(() => {
     if (isTemplatePullSuccess) {
+      if (!serviceAccount) {
+        setErrorMessage('Service account is required');
+        return;
+      }
       if (runName) {
         setErrorMessage('');
         return;
@@ -319,8 +323,12 @@ function NewRunV2(props: NewRunV2Props) {
         setErrorMessage('A pipeline version must be selected');
         return;
       }
+      if (!serviceAccount) {
+        setErrorMessage('Service account is required');
+        return;
+      }
     }
-  }, [runName, existingPipeline, existingPipelineVersion, isTemplatePullSuccess]);
+  }, [runName, existingPipeline, existingPipelineVersion, isTemplatePullSuccess, serviceAccount]);
 
   // Defines the behavior when user clicks `Start` button.
   const newRunMutation = useMutation((run: V2beta1Run) => {
@@ -586,7 +594,7 @@ function NewRunV2(props: NewRunV2Props) {
         <Input
           value={serviceAccount}
           onChange={event => setServiceAccount(event.target.value)}
-          required={false}
+          required={true}
           label='Service Account'
           variant='outlined'
         />


### PR DESCRIPTION
keeping a branch of forked changes, minus the `wf` changes for https://jira.unity3d.com/browse/DPML-406
![Screenshot 2024-04-12 at 1 45 00 PM](https://github.com/Unity-Technologies/pipelines/assets/76134056/ef03d0fe-72f2-4767-8aff-01aa9b8cb8c6)

the code didn't parse the same way, and it looks like https://github.com/kubeflow/pipelines/pull/8487 might have fixed it already